### PR TITLE
Configure secure-tomcat-image to log to STDOUT

### DIFF
--- a/secure-tomcat-image/src/main/docker/Dockerfile
+++ b/secure-tomcat-image/src/main/docker/Dockerfile
@@ -9,6 +9,7 @@ FROM tomcat:7-jre7
 # Changed SHUTDOWN port and Command
 # Increased maxHttpHeaderSize to 65536
 # Set URIEncoding to UTF-8
+# Disable access logging
 ADD server.xml /usr/local/tomcat/conf/
 
 #Put more secured web.xml
@@ -16,6 +17,9 @@ ADD server.xml /usr/local/tomcat/conf/
 # Will not show server version info up on errors and exceptions
 # Added .vtt extension and mime-type
 ADD web.xml /usr/local/tomcat/conf/
+
+#Overwrite logging.properties to send Catalina logs to STDOUT
+ADD logging.properties /usr/local/tomcat/conf/
 
 #Remove version string from HTTP error messages
 #override ServerInfo.properties in catalina.jar

--- a/secure-tomcat-image/src/main/docker/logging.properties
+++ b/secure-tomcat-image/src/main/docker/logging.properties
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.FileHandler, 2localhost.org.apache.juli.FileHandler, 3manager.org.apache.juli.FileHandler, 4host-manager.org.apache.juli.FileHandler, java.util.logging.ConsoleHandler
+
+.handlers = java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.FileHandler.level = FINE
+1catalina.org.apache.juli.FileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.FileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.FileHandler.level = FINE
+2localhost.org.apache.juli.FileHandler.directory = ${catalina.base}/logs
+2localhost.org.apache.juli.FileHandler.prefix = localhost.
+
+3manager.org.apache.juli.FileHandler.level = FINE
+3manager.org.apache.juli.FileHandler.directory = ${catalina.base}/logs
+3manager.org.apache.juli.FileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.FileHandler.level = FINE
+4host-manager.org.apache.juli.FileHandler.directory = ${catalina.base}/logs
+4host-manager.org.apache.juli.FileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = java.util.logging.ConsoleHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = java.util.logging.ConsoleHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE

--- a/secure-tomcat-image/src/main/docker/server.xml
+++ b/secure-tomcat-image/src/main/docker/server.xml
@@ -138,9 +138,9 @@
                 <!-- Access log processes all example.
                      Documentation at: /docs/config/valve.html
                      Note: The pattern used is equivalent to using pattern="common" -->
-                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-                       prefix="localhost_access_log." suffix=".txt"
-                       pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+                <!--<Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"-->
+                       <!--prefix="localhost_access_log." suffix=".txt"-->
+                       <!--pattern="%h %l %u %t &quot;%r&quot; %s %b" />-->
 
             </Host>
         </Engine>


### PR DESCRIPTION
This only affects logging of the Tomcat server itself.  Individual WAR deployments still have full control over their own logging.