### PR TITLE
Add a wkhtmltopdf-service container.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>rabbit-image</module>
         <module>redis-image</module>
         <module>secure-tomcat-image</module>
+        <module>wkhtmltopdf-image</module>
     </modules>
 
     <licenses>

--- a/wkhtmltopdf-image/README.md
+++ b/wkhtmltopdf-image/README.md
@@ -1,0 +1,36 @@
+# WKHtmlToPdf Image
+This docker image definition provides a service wrapper around the command-line open-source wkhtmltopdf generation tool.
+It is based off of the OpenLabs image work [here](https://github.com/openlabs/docker-wkhtmltopdf-aas) with updates
+to include a more recent version of the wkhtmltopdf tool and avoid file-system storage.
+
+This image is designed to be used as a service for generating PDF files from HTML sources.
+
+License information:
+
+Copyright (c) 2014, Openlabs Technologies & Consulting (P) Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/wkhtmltopdf-image/pom.xml
+++ b/wkhtmltopdf-image/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>wkhtmltopdf-image</artifactId>
+  <name>WKHtmlToPdf container image</name>
+  <description>WKHtmlToPdf image for providing html-to-pdf transformations as a microservice.</description>
+  <packaging>pom</packaging>
+
+  <!-- NOTE that this is based off of the secured jre8 Tomcat image work done by Eyal Dahari
+       https://github.com/eyaldahari/docker-secured-tomcat/blob/master/Dockerfile -->
+
+  <parent>
+    <groupId>org.opentestsystem.shared</groupId>
+    <artifactId>container-master</artifactId>
+    <version>3.1.1-SNAPSHOT</version>
+  </parent>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <imageName>${docker.image.prefix}/${project.artifactId}</imageName>
+          <imageTags>
+            <imageTag>${project.version}</imageTag>
+            <imageTag>latest</imageTag>
+          </imageTags>
+          <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/wkhtmltopdf-image/src/main/docker/Dockerfile
+++ b/wkhtmltopdf-image/src/main/docker/Dockerfile
@@ -1,0 +1,27 @@
+################
+# Docker file to build a python container hosting the wkhtmltopdf service.
+################
+
+#Based off of the ubuntu container
+FROM ubuntu:xenial
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    bash wget build-essential xorg libssl-dev libxrender-dev python-pip
+
+RUN pip install werkzeug executor gunicorn
+
+#Install wkhtmltopdf
+RUN wget -O wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
+RUN tar xvfJ wkhtmltox.tar.xz && rm wkhtmltox.tar.xz
+RUN ln -s /wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
+
+ADD app.py /app.py
+EXPOSE 80
+
+ENTRYPOINT ["usr/local/bin/gunicorn"]
+
+# Show the extended help
+CMD ["-b", "0.0.0.0:80", "--log-file", "-", "app:WkHtmlToPdfServer()"]

--- a/wkhtmltopdf-image/src/main/docker/app.py
+++ b/wkhtmltopdf-image/src/main/docker/app.py
@@ -1,0 +1,123 @@
+#! /usr/bin/env python
+import json
+import os
+import tempfile
+
+from executor import execute
+from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.routing import Map, Rule
+from werkzeug.wrappers import Request, Response
+from werkzeug.wsgi import wrap_file
+
+"""
+This python server is responsible for generating PDFs from HTML
+using an underlying wkhtmltopdf command-line tool.
+
+To use this application, the user must send a POST request with
+base64 or form encoded encoded HTML content and the wkhtmltopdf Options in
+request data, with keys 'contents' and 'options'.
+The application will return a response with the PDF file.
+"""
+class WkHtmlToPdfServer():
+    def __init__(self):
+        self.url_map = Map([
+            Rule('/', endpoint='generate_pdf'),
+            Rule('/health', endpoint='health_check')
+        ])
+
+    """
+    Generate a PDF from submitted HTML.
+    """
+    def on_generate_pdf(self, request):
+        if request.method != 'POST':
+            return
+
+        request_is_json = request.content_type.endswith('json')
+
+        with tempfile.NamedTemporaryFile(suffix='.html') as source_file:
+
+            if request_is_json:
+                # If a JSON payload is there, all data is in the payload
+                payload = json.loads(request.data)
+                source_file.write(payload['contents'].decode('base64'))
+                options = payload.get('options', {})
+            elif request.files:
+                # First check if any files were uploaded
+                source_file.write(request.files['file'].read())
+                # Load any options that may have been provided in options
+                options = json.loads(request.form.get('options', '{}'))
+
+            source_file.flush()
+
+            # Evaluate argument to run with subprocess
+            args = ['wkhtmltopdf']
+
+            # Add Global Options
+            if options:
+                for option, value in options.items():
+                    args.append('--%s' % option)
+                    if value:
+                        args.append('"%s"' % value)
+
+            # Add source file name and output file name
+            file_name = source_file.name
+            args += [file_name, file_name + ".pdf"]
+
+            # Execute the command using executor
+            execute(' '.join(args))
+
+            # Define a cleanup closure for removing the output file
+            # once the response is closed.
+            def cleanup():
+                os.remove(file_name + '.pdf')
+
+            response = Response(
+                wrap_file(request.environ, open(file_name + '.pdf')),
+                mimetype='application/pdf',
+            )
+            response.call_on_close(cleanup)
+            return response
+
+    """
+    Respond to a health check request with a 200 Healthy status.
+    """
+    def on_health_check(self, request):
+        return Response(status=200)
+
+    """
+    Respond with 404 for unknown requests.
+    """
+    @staticmethod
+    def error_404():
+        return Response(status=404)
+
+    """
+    Dispatch a request to the associated handler.
+    """
+    def dispatch_request(self, request):
+        adapter = self.url_map.bind_to_environ(request.environ)
+        try:
+            endpoint, values = adapter.match()
+            return getattr(self, 'on_' + endpoint)(request, **values)
+        except NotFound:
+            return self.error_404()
+        except HTTPException, e:
+            return e
+
+    """
+    Initialize the Request object, then dispatch the request.
+    """
+    def wsgi_app(self, environ, start_response):
+        request = Request(environ)
+        response = self.dispatch_request(request)
+        return response(environ, start_response)
+
+    """
+    When called, handle the request.
+    """
+    def __call__(self, environ, start_response):
+        return self.wsgi_app(environ, start_response)
+
+if __name__ == '__main__':
+    from werkzeug.serving import run_simple
+    run_simple('127.0.0.1', 80, WkHtmlToPdfServer(), use_debugger=True, use_reloader=True)

--- a/wkhtmltopdf-image/src/main/docker/app.py
+++ b/wkhtmltopdf-image/src/main/docker/app.py
@@ -46,18 +46,18 @@ class WkHtmlToPdfServer():
             options = json.loads(request.form.get('options', '{}'))
 
         # Evaluate argument to run with subprocess
-        args = ['wkhtmltopdf']
+        args = [u'wkhtmltopdf']
 
         # Add Global Options
         if options:
             for option, value in options.items():
-                args.append('--%s' % option)
+                args.append("--%s" % option)
                 if value:
-                    args.append('"%s"' % value)
+                    args.append('%s' % value)
 
         #Pipe source and output to/from STDIN/STDOUT
-        args.append('-')
-        args.append('-')
+        args.append(u'-')
+        args.append(u'-')
 
         cliProc = Popen(args, stdin=PIPE, stdout=PIPE)
         try:


### PR DESCRIPTION
This creates a wkhtmltopdf-service container that follows the same API as the existing https://github.com/openlabs/docker-wkhtmltopdf-aas container, but:
1. is using ubuntu 16.04 rather than 14.04
2. is using the latest stable release of wkhtmltopdf 12.4

I've uploaded an image to DockerHub as "fwsbac/wkhtmltopdf-image:latest" for testing.

Still TODO:
1. Ask SmarterBalanced to create us a DockerHub "smarterbalanced/wkhtmltopdf-image" container repository that our system user has push rights to. FYI @jtreuting 
2. Change the python app to use stdin/stdout to pipe data to/from the wkhtmltopdf CLI.  Using the file system causes poor performance (~500ms for to generate a PDF from `<!DOCTYPE html><html><body><h1>Hello</h1></body></html>`)