### PR TITLE
Add support for long-running requests and configurable multi-threadin…

### DIFF
--- a/wkhtmltopdf-image/src/main/docker/Dockerfile
+++ b/wkhtmltopdf-image/src/main/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y \
     bash wget build-essential xorg libssl-dev libxrender-dev python-pip
 
-RUN pip install werkzeug executor gunicorn
+RUN pip install werkzeug executor gunicorn futures
 
 #Install wkhtmltopdf
 RUN wget -O wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz
@@ -21,7 +21,7 @@ RUN ln -s /wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
 ADD app.py /app.py
 EXPOSE 80
 
-ENTRYPOINT ["usr/local/bin/gunicorn"]
+ENV NUM_THREADS=2
 
 # Show the extended help
-CMD ["-b", "0.0.0.0:80", "--log-file", "-", "app:WkHtmlToPdfServer()"]
+CMD [ "sh", "-c", "/usr/local/bin/gunicorn -b 0.0.0.0:80 --log-file - -k gthread --threads $NUM_THREADS 'app:WkHtmlToPdfServer()'" ]


### PR DESCRIPTION
…g to wkhtmltopdf-image

This PR changes the Gunicorn python http server to use 'gthread' rather than 'sync' threads to avoid long-running request timeouts.  I've also increased the number of worker threads to 2 by default, which constrains both the memory and CPU usage of the image.

I will push a new image to our development dockerhub repository.

While running load and stability tests, we seemed to get reasonable performance with chunking student reports at 25 reports per PDF, with 2 threads running in the wkhtmltopdf image.

Results while generating IAB/ICA/all subject reports for 473 students:
```
with 2 wkhtmltopdf/step threads
chunk size, time, memory (wkhtmltopdf service usage according to docker) 
50, 5m, 500MB
25, 3m, 250MB
1, 5m, 175MB

with 4 wkhtmltopdf/step threads
25, 3m, 470MB (increased memory/CPU cost, no increase to performance wkhtmltopdf CPU usage at ~300% on my local box)

with 1 wkhtmltopdf thread, 4 step threads
25, 6m, 140MB (wkhtmltopdf CPU usage at ~112% on my local box)

with 2 wkhtmltopdf thread, 4 step threads
25, 3m, 250MB (wkhtmltopdf CPU usage at ~250% on my local box)
```
We'll need to test for stability in a Kubernetes environment, but it looks as though 2 threads with a memory limit of ~350MB and as much CPU as we can spare will hopefully perform reasonably well.  Unfortunately wkhtmltopdf appears to be a bit of a CPU/memory hog.